### PR TITLE
Fix issue where SPNs are skipped if XLSX isn't sorted by PGN

### DIFF
--- a/src/decoda/sae_spec_converter/json_from_da.py
+++ b/src/decoda/sae_spec_converter/json_from_da.py
@@ -258,19 +258,23 @@ def extract_pgns(wb):
 
         pgn_id = int(pgn_id)
         if pgn_id != current_pgn["id"]:
-            # new record found
-            current_pgn = {
-                "id": pgn_id,
-                "name": str(row[name_col]),
-                "acronym": str(row[acronym_col]),
-                "description": str(row[description_col]),
-                "length": int_or_str(row[length_col]),
-                "rate": str(row[rate_col]),
-                "source_document": str(row[document_col]),
-                "spns": [],
-            }
-            result.append(current_pgn)
-
+            # only create a new record if this PGN hasn't been encountered previously
+            result_idx = next((i for i, item in enumerate(result) if item.get('id') == pgn_id), -1)
+            if (result_idx >= 0):
+                current_pgn = result[result_idx]
+            else:
+                current_pgn = {
+                    "id": pgn_id,
+                    "name": str(row[name_col]),
+                    "acronym": str(row[acronym_col]),
+                    "description": str(row[description_col]),
+                    "length": int_or_str(row[length_col]),
+                    "rate": str(row[rate_col]),
+                    "source_document": str(row[document_col]),
+                    "spns": [],
+                }
+                result.append(current_pgn)
+        
         # Only append SPNs that are valid
         spn_id = row[spn_id_col] or ""
         if spn_id != "":


### PR DESCRIPTION
Fixed an issue where SPNs are omitted from the JSON output if XLSX isn't sorted by PGN.  If SPNs for a particular PGN were separated by other rows, they would be detected as duplicates and discarded..

Tried running the JSON converter on `J1939DA MAY23.xlsx` but got warning saying that 100's of the SPN's were duplicates.